### PR TITLE
write nd arrays without W: Seek

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,49 +3,32 @@
 extern crate npy;
 extern crate test;
 
-use npy::{Serialize, Deserialize, AutoSerialize, TypeWrite, TypeRead};
+use npy::{Serialize, Deserialize, AutoSerialize, NpyWriter, OutFile};
 use test::Bencher;
 use test::black_box as bb;
+use std::io::Cursor;
 
 const NITER: usize = 100_000;
 
 macro_rules! gen_benches {
     ($T:ty, $new:expr) => {
         #[inline(never)]
-        fn test_data() -> Vec<u8> {
-            let mut raw = Vec::new();
-            let writer = <$T>::writer(&<$T>::default_dtype()).unwrap();
-            for i in 0usize..NITER {
-                writer.write_one(&mut raw, &$new(i)).unwrap();
-            }
-            raw
-        }
-
-        #[bench]
-        fn read(b: &mut Bencher) {
-            let raw = test_data();
-            b.iter(|| {
-                let dtype = <$T>::default_dtype();
-                let reader = <$T>::reader(&dtype).unwrap();
-
-                let mut remainder = &raw[..];
-                for _ in 0usize..NITER {
-                    let (value, new_remainder) = reader.read_one(remainder);
-                    bb(value);
-                    remainder = new_remainder;
+        fn write_array_via_push() -> Vec<u8> {
+            let cap = 1000 + <$T>::default_dtype().num_bytes() * NITER;
+            let mut cursor = Cursor::new(Vec::with_capacity(cap));
+            {
+                let mut writer = NpyWriter::begin(&mut cursor).unwrap();
+                for i in 0usize..NITER {
+                    writer.push(&$new(i)).unwrap();
                 }
-                assert_eq!(remainder.len(), 0);
-            });
+                writer.finish().unwrap();
+            }
+            cursor.into_inner()
         }
 
         #[bench]
         fn read_to_vec(b: &mut Bencher) {
-            // FIXME: Write to a Cursor<Vec<u8>> once #16 is merged
-            let path = concat!("benches/bench_", stringify!($T), ".npy");
-
-            npy::to_file(path, (0usize..NITER).map($new)).unwrap();
-            let bytes = std::fs::read(path).unwrap();
-
+            let bytes = write_array_via_push();
             b.iter(|| {
                 bb(npy::NpyData::<$T>::from_bytes(&bytes).unwrap().to_vec())
             });
@@ -54,7 +37,7 @@ macro_rules! gen_benches {
         #[bench]
         fn write(b: &mut Bencher) {
             b.iter(|| {
-                bb(test_data())
+                bb(write_array_via_push())
             });
         }
     };

--- a/src/out_file.rs
+++ b/src/out_file.rs
@@ -60,7 +60,6 @@ impl<Row> Builder<Row> {
 }
 
 impl<Row: Serialize> Builder<Row> {
-    // TODO: remove Seek bound via some PanicSeek newtype wrapper
     /// Begin writing an array of known shape.
     pub fn begin_nd<W: Write>(&self, w: W, shape: &[usize]) -> io::Result<NpyWriter<Row, W>> {
         NpyWriter::_begin(self, MaybeSeek::Isnt(w), Some(shape))

--- a/src/out_file.rs
+++ b/src/out_file.rs
@@ -314,6 +314,12 @@ mod maybe_seek {
     impl<W: WriteSeek<W>> MaybeSeek<W> {
         pub fn new_seek(w: W) -> Self {
             let inner = unsafe {
+                // The Self type is W, so all lifetime information contained in the unnamed
+                // lifetime here is also contained in W.
+                //
+                // Because `dyn WriteSeek<W> + '_` is invariant in W, the compiler will
+                // conservatively assume that it carries all borrows held by W; just as if
+                // we *hadn't* erased the lifetime.
                 std::mem::transmute::<
                     Box<dyn WriteSeek<W> + '_>,
                     Box<dyn WriteSeek<W> + 'static>,


### PR DESCRIPTION
this has a use of `unsafe` in order to eliminate a lifetime from the public API.  I think it's correct but I'd like to hear it from someone else...